### PR TITLE
Fixed Initial Lessons Site Build

### DIFF
--- a/lessons/src/main.rs
+++ b/lessons/src/main.rs
@@ -101,6 +101,7 @@ fn run() -> io::Result<()> {
 
     // e.g. `./target/html-lessons/`
     let html_dir = env::current_dir()?.join(TARGET_DIR).join(HTML_DIR);
+    fs::create_dir_all(&html_dir)?;
 
     write_and_log(&html_dir.join("styles.css"), include_str!("styles.css"))?;
     write_and_log(&html_dir.join("favicon.svg"), include_str!("favicon.svg"))?;


### PR DESCRIPTION
The `lessons` project fails to build if the `html-lessons` directory is missing. I ran into this issue when running the project for the first time after completing the Frontend Masters course.

I fixed this by creating the directory right after the path gets built.